### PR TITLE
Update readme for CodeIgniter 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This library registers Monolog as the PHP error handler to catch all errors and 
 
 Supports File (RotatingFileHandler), New Relic (NewRelicHandler) and HipChat (HipChatHandler).
 
-Installation CodeIngiter 2
+Installation CodeIgniter 2
 --------------------------
 * Install monolog with ```composer require monolog/monolog```
 * Make sure your index.php contains  ```include_once './vendor/autoload.php';```

--- a/README.md
+++ b/README.md
@@ -9,11 +9,17 @@ This library registers Monolog as the PHP error handler to catch all errors and 
 
 Supports File (RotatingFileHandler), New Relic (NewRelicHandler) and HipChat (HipChatHandler).
 
-Installation
-------------
+Installation CodeIngiter 2
+--------------------------
 * Install monolog with ```composer require monolog/monolog```
 * Make sure your index.php contains  ```include_once './vendor/autoload.php';```
 * Copy application/libraries/Log.php and application/config/monolog.php into your CodeIgniter application
+
+Installation CodeIngiter 3
+--------------------------
+* Install monolog with ```composer require monolog/monolog```
+* Make sure your index.php contains  ```include_once './vendor/autoload.php';```
+* Copy application/core/Log.php and application/config/monolog.php into your CodeIgniter application
 
 Usage
 -----


### PR DESCRIPTION
Since CodeIgniter 3, Log.php file has been move in core directory. To overwrite log.php from CodeIgniter, we have to move custom Log.php from library to core directory.