### PR TITLE
Adding support for CI 3 and SyslogUDPHandler for external log systems like papertrail

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PhpProjectSharedConfiguration" php_language_level="7.1" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This library registers Monolog as the PHP error handler to catch all errors and 
 
 Supports File (RotatingFileHandler), New Relic (NewRelicHandler), HipChat (HipChatHandler) and Papertrail via SyslogUdpHandler.
 
-Compatible with Codeigniter 3.6 and up
+Compatible with Codeigniter 3.1.6 and up
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Codeigniter-Monolog
+Codeigniter-Monolog - with PaperTrail support
 ===================
 
 Simple integration of the Monolog Package (https://github.com/Seldaek/monolog) into CodeIgniter by overwriting the CI_Log class.
@@ -7,7 +7,7 @@ Based on https://github.com/pfote/Codeigniter-Monolog, but updating monolog to 1
 
 This library registers Monolog as the PHP error handler to catch all errors and adds support for IntrospectionProcessor for additional meta data.
 
-Supports File (RotatingFileHandler), New Relic (NewRelicHandler) and HipChat (HipChatHandler).
+Supports File (RotatingFileHandler), New Relic (NewRelicHandler), HipChat (HipChatHandler) and Papertrail via SyslogUdpHandler.
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -3,17 +3,19 @@ Codeigniter-Monolog - with PaperTrail support
 
 Simple integration of the Monolog Package (https://github.com/Seldaek/monolog) into CodeIgniter by overwriting the CI_Log class.
 
-Based on https://github.com/pfote/Codeigniter-Monolog, but updating monolog to 1.7.* and supporting file logging more akin to native CodeIgniter logging.
+Based on https://github.com/pfote/Codeigniter-Monolog, but updating monolog to 1.22.* and supporting file logging more akin to native CodeIgniter logging.
 
 This library registers Monolog as the PHP error handler to catch all errors and adds support for IntrospectionProcessor for additional meta data.
 
 Supports File (RotatingFileHandler), New Relic (NewRelicHandler), HipChat (HipChatHandler) and Papertrail via SyslogUdpHandler.
 
+Compatible with Codeigniter 3.6 and up
+
 Installation
 ------------
 * Install monolog with ```composer require monolog/monolog```
 * Make sure your index.php contains  ```include_once './vendor/autoload.php';```
-* Copy application/libraries/Log.php and application/config/monolog.php into your CodeIgniter application
+* Copy application/core/MY_Log.php and application/config/monolog.php into your CodeIgniter application
 
 Usage
 -----

--- a/application/config/monolog.php
+++ b/application/config/monolog.php
@@ -1,6 +1,8 @@
 <?php  if (!defined('BASEPATH')) {
     exit('No direct script access allowed');
 }
+
+use Monolog\Logger;
 /*
  * CodeIgniter Monolog integration - Plus Papertrail support
  *
@@ -15,13 +17,13 @@
 /* GENERAL OPTIONS */
 //$config['handlers'] = array('file', 'new_relic', 'hipchat', 'papertrail'); // valid handlers are file | new_relic | hipchat | papertrail
 $config['handlers'] = array('papertrail'); // Send logs to papertrail only
-$config['channel'] = ENVIRONMENT; // channel name which appears on each line of log
-$config['threshold'] = '4'; // 'ERROR' => '1', 'DEBUG' => '2',  'INFO' => '3', 'ALL' => '4'
+$config['channel'] = 'My log'; // channel name which appears on each line of log, use proper naming for control
+$config['threshold'] = '2'; // 'ERROR' => '1', 'DEBUG' => '2',  'INFO' => '3', 'ALL' => '4'
 $config['introspection_processor'] = TRUE; // add some meta data such as controller and line number to log messages
 
-/* PAPERTRAIL OPTIONS*/
-$config['papertrail_hostname'] = 'logsX.papertrailapp.com"';
-$config['papertrail_port'] = 49643;
+/* PAPERTRAIL OPTIONS - Make sure you add the right hostname and port*/
+$config['papertrail_hostname'] = 'logsX.papertrailapp.com';
+$config['papertrail_port'] = '#####';
 
 /* FILE HANDLER OPTIONS
  * Log to default CI log directory (must be writable ie. chmod 757).

--- a/application/config/monolog.php
+++ b/application/config/monolog.php
@@ -2,9 +2,10 @@
     exit('No direct script access allowed');
 }
 /*
- * CodeIgniter Monolog integration
+ * CodeIgniter Monolog integration - Plus Papertrail support
  *
- * (c) Steve Thomas <steve@thomasmultimedia.com.au>
+ * (adjustments) Carlos Umanzor <carlos@nidux.com>
+ * (original idea and concept) Steve Thomas <steve@thomasmultimedia.com.au>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -12,10 +13,15 @@
 
 
 /* GENERAL OPTIONS */
-$config['handlers'] = array('file', 'new_relic', 'hipchat'); // valid handlers are file | new_relic | hipchat
+//$config['handlers'] = array('file', 'new_relic', 'hipchat', 'papertrail'); // valid handlers are file | new_relic | hipchat | papertrail
+$config['handlers'] = array('papertrail'); // Send logs to papertrail only
 $config['channel'] = ENVIRONMENT; // channel name which appears on each line of log
 $config['threshold'] = '4'; // 'ERROR' => '1', 'DEBUG' => '2',  'INFO' => '3', 'ALL' => '4'
 $config['introspection_processor'] = TRUE; // add some meta data such as controller and line number to log messages
+
+/* PAPERTRAIL OPTIONS*/
+$config['papertrail_hostname'] = 'logsX.papertrailapp.com"';
+$config['papertrail_port'] = 49643;
 
 /* FILE HANDLER OPTIONS
  * Log to default CI log directory (must be writable ie. chmod 757).

--- a/application/core/MY_Log.php
+++ b/application/core/MY_Log.php
@@ -12,6 +12,8 @@
  * file that was distributed with this source code.
  */
 
+require_once APPPATH.'vendor/autoload.php';
+
 use Monolog\Logger;
 use Monolog\ErrorHandler;
 use Monolog\Handler\RotatingFileHandler;
@@ -26,7 +28,7 @@ use Monolog\Handler\SyslogUdpHandler;
  * see https://github.com/stevethomas/codeigniter-monolog & https://github.com/Seldaek/monolog
  *
  */
-class CI_Log
+class MY_Log
 {
     // CI log levels
     protected $_levels = array(

--- a/application/libraries/Log.php
+++ b/application/libraries/Log.php
@@ -3,10 +3,10 @@
 }
 
 /*
- * CodeIgniter Monolog integration
+ * CodeIgniter Monolog integration - Plus Papertrail support
  *
- * Version 1.1.1
- * (c) Steve Thomas <steve@thomasmultimedia.com.au>
+ * (adjustments) Carlos Umanzor <carlos@nidux.com>
+ * (original idea and concept) Steve Thomas <steve@thomasmultimedia.com.au>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -18,6 +18,7 @@ use Monolog\Handler\RotatingFileHandler;
 use Monolog\Handler\NewRelicHandler;
 use Monolog\Handler\HipChatHandler;
 use Monolog\Processor\IntrospectionProcessor;
+use Monolog\Handler\SyslogUdpHandler;
 
 /**
  * replaces CI's Logger class, use Monolog instead
@@ -72,14 +73,15 @@ class CI_Log
         // decide which handler(s) to use
         foreach ($this->config['handlers'] as $value) {
             switch ($value) {
+                case 'papertrail':
+                    $handler = new SyslogUdpHandler($this->config['papertrail_hostname'], $this->config['papertrail_port']);
+                    break;
                 case 'file':
                     $handler = new RotatingFileHandler($this->config['file_logfile']);
                     break;
-
                 case 'new_relic':
                     $handler = new NewRelicHandler(Logger::ERROR, true, $this->config['new_relic_app_name']);
                     break;
-
                 case 'hipchat':
                     $handler = new HipChatHandler(
                         $config['hipchat_app_token'],
@@ -88,7 +90,6 @@ class CI_Log
                         $config['hipchat_app_notify'],
                         $config['hipchat_app_loglevel']);
                     break;
-                    
                 default:
                     exit('log handler not supported: ' . $this->config['handler']);
             }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "monolog/monolog": "~1.17"
+        "monolog/monolog": "1.22.0"
     }
 }


### PR DESCRIPTION
- Changes /libraries/Log.php to /core/MY_Log.php for CI 3 compatibility
- Add SyslogUDPHandler in order to support External UDP log receivers like papertrail